### PR TITLE
Missing "cd MacPassHTTP" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ carthage bootstrap --platform Mac
 * Change back to the MacPassHTTP folder, compile and install
 ```bash
 cd ..
+cd MacPassHTTP
 xcodebuild
 ```
 


### PR DESCRIPTION
Just added one missing line to the readme.
